### PR TITLE
[WIP] Add a bookmark tab

### DIFF
--- a/src/components/presentational/HeaderNav.js
+++ b/src/components/presentational/HeaderNav.js
@@ -43,6 +43,10 @@ const HeaderNav = props => (
       <Link prefetch href="/submit">
         <a className={props.currentURL === '/submit' ? 'topsel' : ''}>submit</a>
       </Link>
+      {' | '}
+      <Link prefetch href="/bookmarks">
+        <a className={props.currentURL === '/bookmarks' ? 'topsel' : ''}>bookmarks</a>
+      </Link>
       {
         props.currentURL === '/best' && ' | '
       }

--- a/src/components/presentational/NewsDetail.js
+++ b/src/components/presentational/NewsDetail.js
@@ -8,6 +8,61 @@ import url from 'url';
 import convertNumberToTimeAgo from '../../helpers/convertNumberToTimeAgo';
 
 export default class NewsDetail extends Component {
+  // Constructor method to initiate the "bookmarked" state
+  constructor(props) {
+    super(props);
+    this.state = {
+      bookmarked: false,
+    }
+  }
+  componentDidMount() {
+      this.hydrateStateWithLocalStorage();
+   }
+  //Method to hydrate state component to localStorage
+  hydrateStateWithLocalStorage() {
+    //Handle case when user is not logged in
+    let userId = "guest"
+    if(this.props.me) {
+      userId = this.props.me.id;
+    }
+    if (localStorage.hasOwnProperty(userId)) {
+      // get the key's value from localStorage
+      const userBookmarks = JSON.parse(localStorage.getItem(userId)) || [];
+      //Look if the post has been bookmarked and set the state accordingly
+      const indexItemBookmarked = userBookmarks.findIndex((postItem,i) => postItem.id == this.props.id);
+      indexItemBookmarked !== -1 ? this.setState({ bookmarked: true }) : this.setState({ bookmarked: false });
+    }
+  }
+  //Method to save bookmarks to localStorage and update the bookmark button text
+  saveStateToLocalStorage = () => {
+      //Handle case when user is not logged in
+      let userId = "guest"
+      if(this.props.me) {
+        userId = this.props.me.id;
+      }
+      //get the bookmarks for current user from localStorage
+      const userBookmarks = JSON.parse(localStorage.getItem(userId)) || [];
+      //Look for the postItem element index inside the current user bookmarks
+      const indexItemBookmarked = userBookmarks.findIndex((postItem,i) => postItem.id == this.props.id);
+      //Update state and localStorage depending on actual localStorage and bookmark state
+      if (!this.state.bookmarked) {
+        if(indexItemBookmarked == -1) {
+          //save the bookmark
+          userBookmarks.push(this.props);
+          localStorage.setItem(userId,JSON.stringify(userBookmarks));
+        }
+      } else {
+        if(indexItemBookmarked !== -1) {
+          //remove the bookmark
+          userBookmarks.splice(indexItemBookmarked, 1);
+          localStorage.setItem(userId,JSON.stringify(userBookmarks));
+        }
+      }
+      //change component bookmarked state
+      this.setState({ bookmarked: !this.state.bookmarked });
+    }
+
+  // Added the me props to retrieve logged in user informations
   static propTypes = {
     id: PropTypes.number.isRequired,
     commentCount: PropTypes.number.isRequired,
@@ -19,11 +74,16 @@ export default class NewsDetail extends Component {
     isJobListing: PropTypes.bool,
     submitterId: PropTypes.string.isRequired,
     upvoteCount: PropTypes.number.isRequired,
+    me: PropTypes.shape({
+      id: PropTypes.string,
+      karma: PropTypes.number,
+    })
   }
   static defaultProps = {
     isFavoriteVisible: true,
     isPostScrutinyVisible: false,
     isJobListing: false,
+    me: null,
   }
   static fragments = {
     newsItem: gql`
@@ -94,6 +154,18 @@ export default class NewsDetail extends Component {
                 web
                 </a>
               </span>
+            }
+            {' | '}
+            {
+                <a href="javascript:void(0)" onClick={this.saveStateToLocalStorage}>
+                  {(() => {
+                    switch (this.state.bookmarked) {
+                      case true: return 'unbookmark';
+                      case false: return 'bookmark';
+                      default: return 'bookmark';
+                    }
+                  })()}
+                </a>
             }
             {' | '}
             <Link prefetch href={`/item?id=${this.props.id}`}>

--- a/src/components/presentational/NewsFeed.js
+++ b/src/components/presentational/NewsFeed.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
+//changes
+import { graphql } from 'react-apollo';
 
 import NewsTitle from '../container/NewsTitleWithData';
 import NewsDetail from '../container/NewsDetailWithData';
+//changes
+import meQuery from '../../data/queries/meQuery';
 
 const NewsFeed = (props) => {
   const nextPage = Math.ceil((props.skip || 1) / props.first) + 1;
@@ -28,6 +32,8 @@ const NewsFeed = (props) => {
           isPostScrutinyVisible={props.isPostScrutinyVisible}
           isJobListing={props.isJobListing}
           {...newsItem}
+          //Passing allong current user info
+          me={props.me}
         />,
       );
       rows.push(<tr className="spacer" key={`${newsItem.id.toString()}spacer`} style={{ height: 5 }} />);
@@ -82,6 +88,10 @@ NewsFeed.propTypes = {
   isRankVisible: PropTypes.bool,
   isUpvoteVisible: PropTypes.bool,
   currentURL: PropTypes.string.isRequired,
+  me: PropTypes.shape({
+    id: PropTypes.string,
+    karma: PropTypes.number,
+  })
 };
 NewsFeed.fragments = {
   newsItem: gql`
@@ -95,5 +105,13 @@ NewsFeed.fragments = {
     ${NewsDetail.fragments.newsItem}
   `,
 };
-
-export default NewsFeed;
+//Added the meQuery export
+export default graphql(meQuery, {
+  options: {
+    // fetchPolicy: 'cache-and-network',
+    // ssr: false,
+  },
+  props: ({ data: { me } }) => ({
+    me,
+  }),
+})(NewsFeed);

--- a/src/data/models/NewsItem.js
+++ b/src/data/models/NewsItem.js
@@ -41,6 +41,9 @@ export default class NewsItem {
 
   static hideNewsItem = (id, userId) => DB.hideNewsItem(id, userId);
 
+  // Adrien : Add the id post and userId to localStorage
+  //static bookmarkNewsItem = (id, userId) => localStorage.setItem(`${userId}`, `${id});
+
   static submitNewsItem = ({ submitterId, title, text, url }) => {
     const newsItem = new NewsItem({
       id: (newPostIdCounter += 1),

--- a/src/pages/ask.js
+++ b/src/pages/ask.js
@@ -59,4 +59,3 @@ export default withData((props) => {
     </Main>
   );
 });
-

--- a/src/pages/bookmarks.js
+++ b/src/pages/bookmarks.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import { graphql } from 'react-apollo';
+import Main from '../layouts/Main';
+import NewsFeed from '../components/presentational/NewsFeed';
+import withData from '../helpers/withData';
+import data from '../data/SampleData';
+import meQuery from '../data/queries/meQuery';
+
+// TODO
+ export default withData(props => {
+  return (
+  <Main currentURL={props.url.pathname}>
+    <NewsFeed
+      newsItems={[]}
+    />
+  </Main>
+  )
+});
+
+


### PR DESCRIPTION
This is a spike to explore a "bookmark tab" feature, as part of an exercise. 

> 1. Add a button/link under an post item to bookmark it (store it in localStorage)
> 2. Add a tab to display the bookmarks
> 3. Allow to remove a bookmark from a bookmarked item
> 4. Add a second button to hide news: useful to what you already read



**(1) + (3) I added a button/link under a post item to bookmark or remove it as a bookmarked item.** 
![capture d ecran 2018-06-17 a 08 39 37 1](https://user-images.githubusercontent.com/14063297/41505469-44db4b2e-720a-11e8-9a1e-4162f37cea01.png)
- The logic implemented in this PR is handled by the NewsDetail component which now has got a boolean 'bookmarked' state.
- Bookmarks are stored in localStorage : the key is the user Id and the key's value is an array of all bookmarked NewsDetail props. If the user is not logged in the bookmark is store as a value of "guest" key in localStorage.
- Every time a user bookmark (resp. unbookmark) a post item, the NewsDetail props are saved to (resp. removed from) localStorage using the `saveStateToLocalStorage ` method.
- I added a `hydrateStateWithLocalStorage` method in order to keep hydrated NewsDetail components even if the user changes/refresh page.
- In order to retrieve the logged in user id (which is actually username) information from the database I used the existing meQuery graphql query and  added it to the NewsFeed props.

**Other remarks**

- Ask current user to log in on "bookmark" click.
- Right now a bookmarks update is made everytime the user bookmark/unbookmark. One could just update the bookmark state on every click and call the  `saveStateToLocalStorage ` when the `componentWillUnmount`
- I did store the entire NewsDetail props for post Item that were bookmarks. I did not store only the post Item id because I thought it would be easier then to retrieve this information later for the bookmarks tab. 

**(2) Add a tab to display the bookmarks**

- It is still to be done
- I just added a link in the navbar routing to an empty NewsFeed page and created a `bookmarks.js` page 
- I now would have to retrieve my localStorage information along with the user Id and pass it along to my NewsFeed component. 
- For that matter I would probably have to do a graphql query on localStorage post item id's to retrieve all the props needed for the NewsFeed component, and to ask the user to log in to access the bookmarks tab. 

** (4) Add a second button to hide news: useful to what you already read**
- From what I understand this 'hide' feature is already implemented inside the original repo. 
- I might have missed the point here though.